### PR TITLE
Switch to boost progress_display.hpp

### DIFF
--- a/src/lib/parallel_progress.h
+++ b/src/lib/parallel_progress.h
@@ -23,14 +23,14 @@
 #ifndef VINA_PARALLEL_PROGRESS_H
 #define VINA_PARALLEL_PROGRESS_H
 
-#include <boost/progress.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/timer/progress_display.hpp>
 
 #include "incrementable.h"
 
 struct parallel_progress : public incrementable {
 	parallel_progress() : p(NULL) {}
-	void init(unsigned long n) { p = new boost::progress_display(n); }
+	void init(unsigned long n) { p = new boost::timer::progress_display(n); }
 	void operator++() {
 		if(p) {
 			boost::mutex::scoped_lock self_lk(self);
@@ -40,7 +40,7 @@ struct parallel_progress : public incrementable {
 	virtual ~parallel_progress() { delete p; }
 private:
 	boost::mutex self;
-	boost::progress_display* p;
+	boost::timer::progress_display* p;
 };
 
 #endif


### PR DESCRIPTION
The <boost/progress.hpp> header is deprecated.

The same functionality is available in a supported header
in Boost 1.73 and beyond.